### PR TITLE
Was bored, so I added a ::d2l-shadow pseudo-selector

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -20,6 +20,10 @@ function run(argv, config, entrypoint) {
 	argv.reportDir && args.push('--htmlreport', argv.reportDir);
 	argv.dumpsDir && args.push('-Dd2l.galen.utils.dumps=' + argv.dumpsDir);
 	argv.groups && args.push('--groups', argv.groups);
+	if (argv.enableD2lShadow) {
+		const d2lShadow = require.resolve('../galen/open-shadow-piercing-css-polyfill.js');
+		args.push('-Dd2l.galen.utils.d2lShadow=' + d2lShadow);
+	}
 	args = args.concat(copyEnv(argv.includeEnv), argv._.slice(1));
 
 	const command = [];
@@ -54,6 +58,9 @@ require('yargs')
 	.describe('g', 'comma separated list of groups to run')
 	.alias('g', 'groups')
 	.global('g')
+	.describe('s', 'enable ::d2l-shadow psuedo selector')
+	.alias('s', 'enable-d2l-shadow')
+	.global('s')
 	.command('test <config>', 'Run D2L Galen tests', {
 		entrypoint: {
 			alias: 'e',

--- a/galen/open-shadow-piercing-css-polyfill.js
+++ b/galen/open-shadow-piercing-css-polyfill.js
@@ -1,0 +1,42 @@
+/* global Polymer Element window */
+'use strict';
+
+(function() {
+	if (window.D2LShadowQuerySelector) {
+		return;
+	}
+	var oldQuerySelectorAll = Element.prototype.querySelectorAll;
+	var oldQuerySelector = Element.prototype.querySelector;
+
+	var psuedoSelector = '::d2l-shadow ';
+
+	Element.prototype.querySelectorAll = function querySelectorAll(selector) {
+		if (selector.indexOf(psuedoSelector) === 0) {
+			var newSelector = selector.slice(psuedoSelector.length);
+			if (this.shadowRoot) {
+				return this.shadowRoot.querySelectorAll(newSelector);
+			} else if (Polymer && Polymer.dom && this.root) {
+				return Polymer.dom(this.root).querySelectorAll(newSelector);
+			} else {
+				return this.querySelectorAll(newSelector);
+			}
+		}
+		return oldQuerySelectorAll.apply(this, arguments);
+	};
+
+	Element.prototype.querySelector = function querySelector(selector) {
+		if (selector.indexOf(psuedoSelector) === 0) {
+			var newSelector = selector.slice(psuedoSelector.length);
+			if (this.shadowRoot) {
+				return this.shadowRoot.querySelector(newSelector);
+			} else if (Polymer && Polymer.dom && this.root) {
+				return Polymer.dom(this.root).querySelector(newSelector);
+			} else {
+				return this.querySelector(newSelector);
+			}
+		}
+		return oldQuerySelector.apply(this, arguments);
+	};
+
+	window.D2LShadowQuerySelector = true;
+}());

--- a/galen/polymer-tests.js
+++ b/galen/polymer-tests.js
@@ -1,4 +1,4 @@
-/* global PolymerPage */
+/* global PolymerPage readFile */
 /* eslint no-invalid-this: 0 */
 'use strict';
 
@@ -19,6 +19,10 @@ function polymerTests(browsers, runTests) {
 				var polymerPage;
 
 				function defaultCb(opts) {
+					if (System.getProperty('d2l.galen.utils.d2lShadow')) {
+						driver.executeScript(readFile(System.getProperty('d2l.galen.utils.d2lShadow') + ''));
+						opts.report.info('::d2l-shadow loaded');
+					}
 					if (opts.exportPath) {
 						dumpPage(opts);
 					} else {


### PR DESCRIPTION
To use, add the `-s` option to d2l-galen and use it **at the beginning** of css locators

For example:
```
custom-element-primary	#custom-element-primary
    button              ::d2l-shadow button
```
